### PR TITLE
fix: Add --allow-merge-on-partial-apply flag for GitLab partial apply status (#2125)

### DIFF
--- a/.github/workflows/fork-test-image.yml
+++ b/.github/workflows/fork-test-image.yml
@@ -1,0 +1,100 @@
+name: fork-test-image
+
+# This workflow builds and pushes test images from feature branches in forks.
+# It allows users to test changes before they are merged to the upstream repository.
+#
+# Usage:
+# 1. Push your changes to a branch in your fork
+# 2. The workflow will automatically build and push an image tagged with the branch name
+# 3. Pull the image: docker pull ghcr.io/<your-username>/atlantis:<branch-name>
+#
+# Example: ghcr.io/jamengual/atlantis:fix-gitlab-partial-apply-status
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - 'test/**'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Custom image tag (optional, defaults to branch name)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Test Image
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_REPO: ghcr.io/${{ github.repository }}
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Set up Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version-file: "go.mod"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: arm64,arm
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+    - name: Determine image tag
+      id: tag
+      env:
+        INPUT_TAG: ${{ inputs.image_tag }}
+        BRANCH_REF: ${{ github.ref }}
+      run: |
+        if [ -n "${INPUT_TAG}" ]; then
+          TAG="${INPUT_TAG}"
+        else
+          # Convert branch name to valid docker tag (replace / with -)
+          TAG=$(echo "${BRANCH_REF#refs/heads/}" | sed 's/\//-/g')
+        fi
+        echo "tag=${TAG}" >> $GITHUB_OUTPUT
+        echo "Image will be tagged as: ${TAG}"
+
+    - name: Login to Packages Container registry
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push test image
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: .
+        build-args: |
+          ATLANTIS_BASE_TAG_TYPE=alpine
+          ATLANTIS_VERSION=${{ steps.tag.outputs.tag }}
+          ATLANTIS_COMMIT=${{ github.sha }}
+          ATLANTIS_DATE=${{ github.event.repository.updated_at }}
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ${{ env.DOCKER_REPO }}:${{ steps.tag.outputs.tag }}
+          ${{ env.DOCKER_REPO }}:${{ steps.tag.outputs.tag }}-${{ github.sha }}
+        target: alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
 # what distro is the image being built for
-ARG ALPINE_TAG=3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+ARG ALPINE_TAG=3.23.2@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 ARG DEBIAN_TAG=12.13-slim@sha256:56ff6d36d4eb3db13a741b342ec466f121480b5edded42e4b7ee850ce7a418ee
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GOLANG_TAG=1.25.4-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
@@ -37,7 +37,7 @@ WORKDIR /app
 # This is needed to download transitive dependencies instead of compiling them
 # https://github.com/montanaflynn/golang-docker-cache
 # https://github.com/golang/go/issues/27719
-# renovate: datasource=repology depName=alpine_3_21/bash versioning=loose
+# renovate: datasource=repology depName=alpine_3_22/bash versioning=loose
 ENV BUILDER_BASH_VERSION="5.2.37-r0"
 RUN apk add --no-cache \
         bash=${BUILDER_BASH_VERSION}
@@ -176,24 +176,24 @@ COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# renovate: datasource=repology depName=alpine_3_21/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20250911-r0"
-# renovate: datasource=repology depName=alpine_3_21/curl versioning=loose
-ENV CURL_VERSION="8.14.1-r2"
-# renovate: datasource=repology depName=alpine_3_21/git versioning=loose
-ENV GIT_VERSION="2.47.3-r0"
-# renovate: datasource=repology depName=alpine_3_21/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-r15"
-# renovate: datasource=repology depName=alpine_3_21/bash versioning=loose
-ENV BASH_VERSION="5.2.37-r0"
-# renovate: datasource=repology depName=alpine_3_21/openssh versioning=loose
-ENV OPENSSH_VERSION="9.9_p2-r0"
-# renovate: datasource=repology depName=alpine_3_21/dumb-init versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
+ENV CA_CERTIFICATES_VERSION="20251003-r0"
+# renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
+ENV CURL_VERSION="8.17.0-r1"
+# renovate: datasource=repology depName=alpine_3_23/git versioning=loose
+ENV GIT_VERSION="2.52.0-r0"
+# renovate: datasource=repology depName=alpine_3_23/unzip versioning=loose
+ENV UNZIP_VERSION="6.0-r16"
+# renovate: datasource=repology depName=alpine_3_23/bash versioning=loose
+ENV BASH_VERSION="5.3.3-r1"
+# renovate: datasource=repology depName=alpine_3_23/openssh versioning=loose
+ENV OPENSSH_VERSION="10.2_p1-r0"
+# renovate: datasource=repology depName=alpine_3_23/dumb-init versioning=loose
 ENV DUMB_INIT_VERSION="1.2.5-r3"
-# renovate: datasource=repology depName=alpine_3_21/gcompat versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/gcompat versioning=loose
 ENV GCOMPAT_VERSION="1.1.0-r4"
-# renovate: datasource=repology depName=alpine_3_21/coreutils versioning=loose
-ENV COREUTILS_ENV_VERSION="9.5-r2"
+# renovate: datasource=repology depName=alpine_3_23/coreutils versioning=loose
+ENV COREUTILS_ENV_VERSION="9.8-r1"
 
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -163,6 +163,7 @@ const (
 	WebUsernameFlag                  = "web-username"
 	WebPasswordFlag                  = "web-password"
 	WebsocketCheckOrigin             = "websocket-check-origin"
+	AllowMergeOnPartialApplyFlag     = "allow-merge-on-partial-apply"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser                  = ""
@@ -653,6 +654,12 @@ var boolFlags = map[string]boolFlag{
 	UseTFPluginCache: {
 		description:  "Enable the use of the Terraform plugin cache",
 		defaultValue: true,
+	},
+	AllowMergeOnPartialApplyFlag: {
+		description: "When set to true, partial applies will show a success status instead of pending, " +
+			"allowing merges before all projects are applied. " +
+			"Useful for GitLab users experiencing issue #2125 where the apply status blocks merges.",
+		defaultValue: false,
 	},
 }
 var intFlags = map[string]intFlag{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -65,6 +65,7 @@ var testFlags = map[string]any{
 	AutoplanModulesFromProjects:      "",
 	AllowCommandsFlag:                "version,plan,apply,unlock,import,approve_policies",
 	AllowForkPRsFlag:                 true,
+	AllowMergeOnPartialApplyFlag:     false,
 	APISecretFlag:                    "",
 	AutoDiscoverModeFlag:             "auto",
 	AutomergeFlag:                    true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "vite": "6.4.1",
         "vitepress": "1.6.4",
         "vitepress-plugin-mermaid": "2.0.17",
-        "vue": "3.5.26"
+        "vue": "3.5.27"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1830,23 +1830,23 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
-      "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+      "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.26",
+        "@vue/shared": "3.5.27",
         "entities": "^7.0.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/entities": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-      "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1857,28 +1857,28 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
-      "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+      "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-core": "3.5.27",
+        "@vue/shared": "3.5.27"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
-      "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+      "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.26",
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/compiler-ssr": "3.5.26",
-        "@vue/shared": "3.5.26",
+        "@vue/compiler-core": "3.5.27",
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.6",
@@ -1886,14 +1886,14 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
-      "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+      "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/shared": "3.5.27"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1933,57 +1933,57 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
-      "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+      "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.26"
+        "@vue/shared": "3.5.27"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
-      "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+      "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/reactivity": "3.5.27",
+        "@vue/shared": "3.5.27"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
-      "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+      "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.26",
-        "@vue/runtime-core": "3.5.26",
-        "@vue/shared": "3.5.26",
+        "@vue/reactivity": "3.5.27",
+        "@vue/runtime-core": "3.5.27",
+        "@vue/shared": "3.5.27",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
-      "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+      "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27"
       },
       "peerDependencies": {
-        "vue": "3.5.26"
+        "vue": "3.5.27"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
-      "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+      "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5986,17 +5986,17 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
-      "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+      "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.26",
-        "@vue/compiler-sfc": "3.5.26",
-        "@vue/runtime-dom": "3.5.26",
-        "@vue/server-renderer": "3.5.26",
-        "@vue/shared": "3.5.26"
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-sfc": "3.5.27",
+        "@vue/runtime-dom": "3.5.27",
+        "@vue/server-renderer": "3.5.27",
+        "@vue/shared": "3.5.27"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vite": "6.4.1",
     "vitepress": "1.6.4",
     "vitepress-plugin-mermaid": "2.0.17",
-    "vue": "3.5.26"
+    "vue": "3.5.27"
   },
   "scripts": {
     "website:dev": "vitepress dev --host localhost --port 8080 runatlantis.io",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -95,6 +95,21 @@ Atlantis will automatically run `terraform plan`
 which can run arbitrary code if given a malicious Terraform configuration.
 :::
 
+### `--allow-merge-on-partial-apply`
+
+```bash
+atlantis server --allow-merge-on-partial-apply
+# or
+ATLANTIS_ALLOW_MERGE_ON_PARTIAL_APPLY=true
+```
+
+When set to `true`, partial applies (where some projects have been applied but others
+remain) will show a "success" commit status instead of "pending". This allows merging
+PRs before all projects have been applied. Defaults to `false`.
+
+**Use case**: GitLab users experiencing [issue #2125](https://github.com/runatlantis/atlantis/issues/2125)
+where the `atlantis/apply` status stays in "running" state and blocks merges on multi-project PRs.
+
 ### `--api-secret` <Badge text="v0.22.2+" type="info"/>
 
 ```bash

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1590,6 +1590,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		silenceNoProjects,
 		false,
 		e2ePullReqStatusFetcher,
+		false,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/import-single-project/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/import-workspace/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-workspace/dir1/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "3.8.0"
     }
   }
 }

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -27,6 +27,7 @@ func NewApplyCommandRunner(
 	SilenceNoProjects bool,
 	silenceVCSStatusNoProjects bool,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
+	allowMergeOnPartialApply bool,
 ) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
 		vcsClient:                  vcsClient,
@@ -44,6 +45,7 @@ func NewApplyCommandRunner(
 		SilenceNoProjects:          SilenceNoProjects,
 		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
 		pullReqStatusFetcher:       pullReqStatusFetcher,
+		allowMergeOnPartialApply:   allowMergeOnPartialApply,
 	}
 }
 
@@ -68,6 +70,9 @@ type ApplyCommandRunner struct {
 	// are found
 	silenceVCSStatusNoProjects bool
 	SilencePRComments          []string
+	// allowMergeOnPartialApply when true shows Success status instead of Pending
+	// for partial applies, allowing merges before all projects are applied.
+	allowMergeOnPartialApply bool
 }
 
 func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
@@ -202,9 +207,15 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 	if numErrored > 0 {
 		status = models.FailedCommitStatus
 	} else if numSuccess < len(pullStatus.Projects) {
-		// If there are plans that haven't been applied yet, we'll use a pending
-		// status.
-		status = models.PendingCommitStatus
+		// Partial apply: some projects not yet applied
+		if a.allowMergeOnPartialApply {
+			// User opted-in: show success to allow merge
+			ctx.Log.Debug("Partial apply with --allow-merge-on-partial-apply=true, showing success")
+			status = models.SuccessCommitStatus
+		} else {
+			// Default: show pending to block merge until all applied
+			status = models.PendingCommitStatus
+		}
 	}
 
 	if err := a.commitStatusUpdater.UpdateCombinedCount(

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -531,3 +531,138 @@ func TestApplyCommandRunner_ExecutionOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCommandRunner_AllowMergeOnPartialApply(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+
+	cases := []struct {
+		Description              string
+		AllowMergeOnPartialApply bool
+		PrePopulatedProjects     []command.ProjectResult  // Projects to store in DB before apply (simulates prior plan)
+		NewApplyResults          []command.ProjectContext // Projects being applied in this run
+		ExpectedStatus           models.CommitStatus
+		ExpectedNumSuccess       int
+		ExpectedNumTotal         int
+	}{
+		{
+			Description:              "Default flag (false): partial apply shows Pending status",
+			AllowMergeOnPartialApply: false,
+			// Simulate: user planned 2 projects, now applying only 1
+			PrePopulatedProjects: []command.ProjectResult{
+				{Command: command.Plan, RepoRelDir: "dir1", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+				{Command: command.Plan, RepoRelDir: "dir2", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+			},
+			NewApplyResults: []command.ProjectContext{
+				{CommandName: command.Apply, RepoRelDir: "dir1", Workspace: "default", ProjectPlanStatus: models.PlannedPlanStatus},
+			},
+			ExpectedStatus:     models.PendingCommitStatus,
+			ExpectedNumSuccess: 1, // dir1 applied
+			ExpectedNumTotal:   2, // dir1 + dir2
+		},
+		{
+			Description:              "Flag enabled: partial apply shows Success status to allow merge",
+			AllowMergeOnPartialApply: true,
+			// Simulate: user planned 2 projects, now applying only 1
+			PrePopulatedProjects: []command.ProjectResult{
+				{Command: command.Plan, RepoRelDir: "dir1", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+				{Command: command.Plan, RepoRelDir: "dir2", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+			},
+			NewApplyResults: []command.ProjectContext{
+				{CommandName: command.Apply, RepoRelDir: "dir1", Workspace: "default", ProjectPlanStatus: models.PlannedPlanStatus},
+			},
+			ExpectedStatus:     models.SuccessCommitStatus, // With flag, partial apply shows success
+			ExpectedNumSuccess: 1,                          // dir1 applied
+			ExpectedNumTotal:   2,                          // dir1 + dir2
+		},
+		{
+			Description:              "All projects applied: always shows Success (flag=false)",
+			AllowMergeOnPartialApply: false,
+			// Simulate: user planned 1 project, now applying it
+			PrePopulatedProjects: []command.ProjectResult{
+				{Command: command.Plan, RepoRelDir: "dir1", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+			},
+			NewApplyResults: []command.ProjectContext{
+				{CommandName: command.Apply, RepoRelDir: "dir1", Workspace: "default", ProjectPlanStatus: models.PlannedPlanStatus},
+			},
+			ExpectedStatus:     models.SuccessCommitStatus,
+			ExpectedNumSuccess: 1,
+			ExpectedNumTotal:   1, // All applied
+		},
+		{
+			Description:              "All projects applied: always shows Success (flag=true)",
+			AllowMergeOnPartialApply: true,
+			// Simulate: user planned 1 project, now applying it
+			PrePopulatedProjects: []command.ProjectResult{
+				{Command: command.Plan, RepoRelDir: "dir1", Workspace: "default", ProjectCommandOutput: command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}},
+			},
+			NewApplyResults: []command.ProjectContext{
+				{CommandName: command.Apply, RepoRelDir: "dir1", Workspace: "default", ProjectPlanStatus: models.PlannedPlanStatus},
+			},
+			ExpectedStatus:     models.SuccessCommitStatus,
+			ExpectedNumSuccess: 1,
+			ExpectedNumTotal:   1, // All applied
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			// create an empty DB
+			tmp := t.TempDir()
+			db, err := boltdb.New(tmp)
+			t.Cleanup(func() {
+				db.Close()
+			})
+			Ok(t, err)
+
+			_ = setup(t, func(tc *TestConfig) {
+				tc.allowMergeOnPartialApply = c.AllowMergeOnPartialApply
+				tc.database = db
+			})
+
+			scopeNull := metricstest.NewLoggingScope(t, logger, "atlantis")
+
+			pull := &github.PullRequest{
+				State: github.Ptr("open"),
+			}
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+			When(githubGetter.GetPullRequest(logger, testdata.GithubRepo, testdata.Pull.Num)).ThenReturn(pull, nil)
+			When(eventParsing.ParseGithubPull(logger, pull)).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+			// Pre-populate DB with planned projects (simulates prior `atlantis plan`)
+			if len(c.PrePopulatedProjects) > 0 {
+				_, err = db.UpdatePullWithResults(modelPull, c.PrePopulatedProjects)
+				Ok(t, err)
+			}
+
+			ctx := &command.Context{
+				User:     testdata.User,
+				Log:      logging.NewNoopLogger(t),
+				Scope:    scopeNull,
+				Pull:     modelPull,
+				HeadRepo: testdata.GithubRepo,
+				Trigger:  command.CommentTrigger,
+			}
+
+			cmd := &events.CommentCommand{Name: command.Apply}
+			When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn(c.NewApplyResults, nil)
+			for i := range c.NewApplyResults {
+				When(projectCommandRunner.Apply(c.NewApplyResults[i])).ThenReturn(command.ProjectCommandOutput{
+					ApplySuccess: "Success!",
+				})
+			}
+
+			applyCommandRunner.Run(ctx, cmd)
+
+			commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+				Any[logging.SimpleLogging](),
+				Any[models.Repo](),
+				Any[models.PullRequest](),
+				Eq[models.CommitStatus](c.ExpectedStatus),
+				Eq[command.Name](command.Apply),
+				Eq(c.ExpectedNumSuccess),
+				Eq(c.ExpectedNumTotal),
+			)
+		})
+	}
+}

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -80,6 +80,7 @@ type TestConfig struct {
 	database                   db.Database
 	DisableUnlockLabel         string
 	PendingApplyStatus         bool
+	allowMergeOnPartialApply   bool
 }
 
 func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.MockClient {
@@ -189,6 +190,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		testConfig.SilenceNoProjects,
 		testConfig.silenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		testConfig.allowMergeOnPartialApply,
 	)
 
 	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(

--- a/server/server.go
+++ b/server/server.go
@@ -812,6 +812,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SilenceNoProjects,
 		userConfig.SilenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		userConfig.AllowMergeOnPartialApply,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -137,6 +137,7 @@ type UserConfig struct {
 	WriteGitCreds              bool            `mapstructure:"write-git-creds"`
 	WebsocketCheckOrigin       bool            `mapstructure:"websocket-check-origin"`
 	UseTFPluginCache           bool            `mapstructure:"use-tf-plugin-cache"`
+	AllowMergeOnPartialApply   bool            `mapstructure:"allow-merge-on-partial-apply"`
 }
 
 // ToAllowCommandNames parse AllowCommands into a slice of CommandName


### PR DESCRIPTION
## Summary

This PR fixes [issue #2125](https://github.com/runatlantis/atlantis/issues/2125) where GitLab's aggregate `atlantis/apply` commit status stays in "running" state after partial applies on multi-project PRs, blocking merges even when some projects have successfully applied.

## Problem

When running `atlantis apply` on a multi-project PR in GitLab:

1. User runs `atlantis apply -d dir1` (partial apply targeting one project)
2. The project in `dir1` applies successfully
3. Other projects remain in "planned" state
4. `ApplyCommandRunner.updateCommitStatus()` detects this as a partial apply:
   ```go
   } else if numSuccess < len(pullStatus.Projects) {
       status = models.PendingCommitStatus  // ← This blocks GitLab merges!
   }
   ```
5. GitLab maps `PendingCommitStatus` to `gitlab.Running` status
6. The PR cannot be merged because the `atlantis/apply` check shows "running"

## Root Cause

The `updateCommitStatus` method in `apply_command_runner.go` intentionally sets a **Pending** status for partial applies to prevent premature merges. However, GitLab interprets "Pending" as "Running", which:
- Shows a perpetually spinning status indicator
- Blocks merges if branch protection requires status checks to pass
- Creates confusion as users expect "Pending" to mean "waiting to start"

## Solution: Opt-In Flag

Add a new flag `--allow-merge-on-partial-apply` that, when enabled, shows a **Success** status instead of **Pending** for partial applies. This allows affected GitLab users to merge PRs before all projects have been applied.

### Design Principles

1. **Zero breaking changes** - Default behavior unchanged for all users
2. **Opt-in only** - Users must explicitly enable the new behavior
3. **VCS-agnostic** - Flag works the same for all VCS providers (GitHub, GitLab, Bitbucket, etc.)

### Behavior Matrix

| Scenario | `--allow-merge-on-partial-apply=false` (default) | `--allow-merge-on-partial-apply=true` |
|----------|------------------------------------------------|--------------------------------------|
| All projects applied | ✅ Success | ✅ Success |
| Partial apply (some projects remain) | ⏳ Pending (blocks GitLab merge) | ✅ Success (allows merge) |
| Any errors during apply | ❌ Failed | ❌ Failed |

## Changes

### Core Implementation

| File | Change |
|------|--------|
| `cmd/server.go` | Add `AllowMergeOnPartialApplyFlag` constant and Viper binding |
| `server/user_config.go` | Add `AllowMergeOnPartialApply` config field with mapstructure tag |
| `server/events/apply_command_runner.go` | Add flag to struct and conditional logic in `updateCommitStatus()` |
| `server/server.go` | Wire flag from UserConfig to ApplyCommandRunner constructor |

### Tests

| File | Change |
|------|--------|
| `server/events/apply_command_runner_test.go` | Add `TestApplyCommandRunner_AllowMergeOnPartialApply` with 4 test cases |
| `server/events/command_runner_test.go` | Add field to `TestConfig` struct |
| `cmd/server_test.go` | Add flag to `testFlags` for `TestUserConfigAllTested` |
| `server/controllers/events/events_controller_e2e_test.go` | Update constructor call |

### Documentation

| File | Change |
|------|--------|
| `runatlantis.io/docs/server-configuration.md` | Add comprehensive flag documentation |

### Fork Testing Workflow

| File | Change |
|------|--------|
| `.github/workflows/fork-test-image.yml` | New workflow to build test images from feature branches |

## Usage

### Server Configuration

```bash
# Command line
atlantis server --allow-merge-on-partial-apply

# Environment variable
ATLANTIS_ALLOW_MERGE_ON_PARTIAL_APPLY=true
```

### Testing with Docker Image

A test image is automatically built from this branch. You can test it with:

```bash
docker pull ghcr.io/jamengual/atlantis:fix-gitlab-partial-apply-status-2125
```

Or use the short SHA variant:
```bash
docker pull ghcr.io/jamengual/atlantis:fix-gitlab-partial-apply-status-2125-<sha>
```

## Test Plan

- [x] Unit tests covering all status combinations with flag true/false
- [x] Verify default behavior (flag=false) matches current behavior exactly
- [x] Verify flag=true allows merge on partial apply
- [x] Test with pre-populated DB to simulate multi-project scenarios
- [x] All existing tests pass (`go test ./...`)
- [x] Documentation added to server-configuration.md
- [ ] Manual testing with GitLab (using test image from this fork)

## Backward Compatibility

- ✅ **100% backward compatible** - Default behavior unchanged for ALL users
- ✅ **Opt-in only** - Users must explicitly set `--allow-merge-on-partial-apply=true`
- ✅ **All VCS providers** - Flag works the same regardless of VCS type
- ✅ **No breaking changes** - Existing configurations continue to work exactly as before

## Related Issues

- Fixes #2125

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)