### PR TITLE
fix: prevent index out of bounds in API plan when cmds and cc arrays …

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -140,23 +140,16 @@ func (a *APIController) Plan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
+
 	result, err := a.apiPlan(request, ctx)
 	if err != nil {
 		responder.InternalError(w, r, err)
 		return
 	}
-	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
 
-	// Convert to API response format
 	apiResult := NewCommandResultAPI(result, command.Plan.String())
-
-	// Determine HTTP status based on result
-	httpCode := http.StatusOK
-	if result.HasErrors() {
-		httpCode = http.StatusInternalServerError
-	}
-
-	responder.Success(w, r, httpCode, apiResult)
+	responder.Success(w, r, http.StatusOK, apiResult)
 }
 
 func (a *APIController) Apply(w http.ResponseWriter, r *http.Request) {
@@ -333,8 +326,18 @@ func (a *APIController) apiPlan(request *APIRequest, ctx *command.Context) (*com
 		ctx.Log.Warn("unable to update plan commit status: %s", err)
 	}
 
+	ctx.Log.Info("getCommands returned: cmds length=%d, cc length=%d", len(cmds), len(cc))
+
 	var projectResults []command.ProjectResult
 	for i, cmd := range cmds {
+		// Defensive check for cc array bounds
+		// Stops the panic that returns 500 error for GitLab type
+		// More work is needed to figure out why the mismatch happens in the getCommands method
+		if i >= len(cc) {
+			ctx.Log.Warn("skipping iteration %d: cc array only has %d elements, cannot access cc[%d]", i, len(cc), i)
+			continue
+		}
+
 		err = a.PreWorkflowHooksCommandRunner.RunPreHooks(ctx, cc[i])
 		if err != nil {
 			if a.FailOnPreWorkflowHookError {
@@ -347,6 +350,7 @@ func (a *APIController) apiPlan(request *APIRequest, ctx *command.Context) (*com
 
 		a.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cc[i]) // nolint: errcheck
 	}
+
 	return &command.Result{ProjectResults: projectResults}, nil
 }
 
@@ -923,12 +927,12 @@ func (a *APIController) DetectDrift(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
 	result, err := a.apiPlan(apiRequest, ctx)
 	if err != nil {
 		responder.InternalError(w, r, err)
 		return
 	}
-	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
 
 	// Process results and store drift data
 	detectionResult := models.NewDriftDetectionResult(request.Repository)

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -148,8 +148,14 @@ func (a *APIController) Plan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Determine HTTP status based on result
+	httpCode := http.StatusOK
+	if result.HasErrors() {
+		httpCode = http.StatusInternalServerError
+	}
+
 	apiResult := NewCommandResultAPI(result, command.Plan.String())
-	responder.Success(w, r, http.StatusOK, apiResult)
+	responder.Success(w, r, httpCode, apiResult)
 }
 
 func (a *APIController) Apply(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## what

Quick mitigation for Atlantis API returning 500's due to a panic when accessing out of bounds view.


## why

500's are bad 😄 

I'll do a more detailed investigation into _why_ this is failing, I'd want to leave this code here regardless IMO it doesn't hurt to have more checks in place.

## tests
Before:
```
➜  curl --request POST 'http://127.0.0.1:4141/api/plan' \                                                                               
--header 'X-Atlantis-Token: supasecrettoken' \
--header 'Content-Type: application/json' \
--data-raw '{
    "Repository": "my/iac/repo",
    "Ref": "main",
    "Type": "Gitlab",
    "Paths": [{
      "Directory": "my/infra/dir",
      "Workspace": "my_infra_workspace"
    }]
}'

500 Internal Server Error% 
```
After:
```
{
"success": true,
"data": {
    "command": "plan",
    "projects": [
        {
            "project_name": "",
            "directory": "my/dir",
            "workspace": "my_dir",
            "command": "plan",
            "status": "success",
            "output": "16:49:45.576 WARN   The following strict control(s) are already completed: skip-dependencies-inputs. Please remove any completed strict controls, as setting them no longer does anything. For a list of all ongoing strict controls, and the outcomes of previous strict controls, see https://terragrunt.gruntwork.io/docs/reference/strict-mode or get the actual list by running the `terragrunt info strict` command.\n16:49:47.547 WARN   The following strict control(s) are already completed: skip-dependencies-inputs. Please remove any completed strict controls, as setting them no longer does anything. For a list of all ongoing strict controls, and the outcomes of previous strict controls, see https://terragrunt.gruntwork.io/docs/reference/strict-mode or get the actual list by running the `terragrunt info strict` command.\n16:49:50.960 STDOUT tofu: null_resource.null[0]: Refreshing state... [id=2596784952688210542]\n16:49:50.960 STDOUT tofu: null_resource.null[1]: Refreshing state... [id=2787498185147013395]\n16:49:50.960 STDOUT tofu: null_resource.null[2]: Refreshing state... [id=5456944428832866491]\n16:49:51.106 STDOUT tofu: No changes. Your infrastructure matches the configuration.\n16:49:51.106 STDOUT tofu: OpenTofu has compared your real infrastructure against your configuration and\n16:49:51.106 STDOUT tofu: found no differences, so no changes are needed.\n",
            "plan": {
                "has_changes": false,
                "to_add": 0,
                "to_change": 0,
                "to_destroy": 0,
                "to_import": 0,
                "summary": "No changes. Your infrastructure matches the configuration."
            }
        }
    ],
    "total_projects": 1,
    "success_count": 1,
    "failure_count": 0,
    "executed_at": "2026-01-29T16:49:51.739215238Z"
},
"request_id": "47dee9bcf6cc5d9252cb4375a5e8be07",
"timestamp": "2026-01-29T16:49:51.739241868Z"
}
```

